### PR TITLE
Require msgpack==0.5.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # List required packages in this file, one per line.
 event-model >=1.8.0
-msgpack
+msgpack==0.5.6
 msgpack_numpy
 suitcase-utils


### PR DESCRIPTION
As discussed in NSLS-II Slack with @danielballan and @tacaswell, this is to avoid issues like this: https://github.com/explosion/spaCy/issues/2995.

That's what was observed with a dataset from a beamline:
```py
ValueError                                Traceback (most recent call last)
<ipython-input-4-1a8a36c6268b> in <module>
      1 with open(filepath, 'rb') as file:
      2     unpacker = msgpack.Unpacker(file, object_hook=msgpack_numpy.decode, encoding='utf-8')
----> 3     for name, doc in unpacker:
      4         print(name, doc)
      5

msgpack/_unpacker.pyx in msgpack._cmsgpack.Unpacker.__next__()

msgpack/_unpacker.pyx in msgpack._cmsgpack.Unpacker._unpack()

ValueError: 2301000 exceeds max_bin_len(1048576)
```