### PR TITLE
updating to the new `file_prefix` API

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ flake8
 git+git://github.com/NSLS-II/ophyd@ophyd-for-suitcase-utils
 pytest >=3.9
 sphinx
-suitcase-utils[test_fixtures] >=0.1.0rc2
+suitcase-utils[test_fixtures] >=0.1.4rc1
 # These are dependencies of various sphinx extensions for documentation.
 ipython
 matplotlib

--- a/suitcase/msgpack/__init__.py
+++ b/suitcase/msgpack/__init__.py
@@ -14,7 +14,7 @@ __version__ = get_versions()['version']
 del get_versions
 
 
-def export(gen, directory, file_prefix='{uid}', **kwargs):
+def export(gen, directory, file_prefix='{start[uid]}', **kwargs):
     """
     Export a stream of documents to msgpack.
 
@@ -43,9 +43,10 @@ def export(gen, directory, file_prefix='{uid}', **kwargs):
 
     file_prefix : str, optional
         The first part of the filename of the generated output files. This
-        string may include templates as in ``{proposal_id}-{sample_name}-``,
+        string may include templates as in
+        ``{start[proposal_id]}-{start[sample_name]}-``,
         which are populated from the RunStart document. The default value is
-        ``{uid}-`` which is guaranteed to be present and unique. A more
+        ``{start[uid]}-`` which is guaranteed to be present and unique. A more
         descriptive value depends on the application and is therefore left to
         the user.
 
@@ -67,11 +68,11 @@ def export(gen, directory, file_prefix='{uid}', **kwargs):
 
     Generate files with more readable metadata in the file names.
 
-    >>> export(gen, '', '{plan_name}-{motors}-')
+    >>> export(gen, '', '{start[plan_name]}-{start[motors]}-')
 
     Include the experiment's start time formatted as YYYY-MM-DD_HH-MM.
 
-    >>> export(gen, '', '{time:%Y-%m-%d_%H:%M}-')
+    >>> export(gen, '', '{start[time]:%Y-%m-%d_%H:%M}-')
 
     Place the files in a different directory, such as on a mounted USB stick.
 
@@ -110,9 +111,10 @@ class Serializer(event_model.DocumentRouter):
 
     file_prefix : str, optional
         The first part of the filename of the generated output files. This
-        string may include templates as in ``{proposal_id}-{sample_name}-``,
+        string may include templates as in
+        ``{start[proposal_id]}-{start[sample_name]}-``,
         which are populated from the RunStart document. The default value is
-        ``{uid}-`` which is guaranteed to be present and unique. A more
+        ``{start[uid]}-`` which is guaranteed to be present and unique. A more
         descriptive value depends on the application and is therefore left to
         the user.
 
@@ -125,7 +127,7 @@ class Serializer(event_model.DocumentRouter):
         dict mapping the 'labels' to lists of file names (or, in general,
         whatever resources are produced by the Manager)
     """
-    def __init__(self, directory, file_prefix='{uid}', **kwargs):
+    def __init__(self, directory, file_prefix='{start[uid]}-', **kwargs):
 
         self._file_prefix = file_prefix
         self._kwargs = kwargs
@@ -159,9 +161,9 @@ class Serializer(event_model.DocumentRouter):
 
     def start(self, doc):
         # Fill in the file_prefix with the contents of the RunStart document.
-        # As in, '{uid}' -> 'c1790369-e4b2-46c7-a294-7abfa239691a'
+        # As in, '{tart[uid]}' -> 'c1790369-e4b2-46c7-a294-7abfa239691a'
         # or 'my-data-from-{plan-name}' -> 'my-data-from-scan'
-        filename = f'{self._file_prefix.format(**doc)}.msgpack'
+        filename = f'{self._file_prefix.format(start=doc)}.msgpack'
         self._buffer = self._manager.open('all', filename, 'xb')
         self._buffer.write(_encode(('start', doc)))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from bluesky.tests.conftest import RE  # noqa
 from ophyd.tests.conftest import hw  # noqa
 from suitcase.utils.tests.conftest import (  # noqa
-    example_data, generate_data, plan_type, detector_list, event_type) # noqa
+    example_data, generate_data, plan_type, detector_list, event_type,
+    file_prefix_list) # noqa

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -11,3 +11,26 @@ def test_export(tmp_path, example_data):
     # For extra credit, capture the return value from export in a variable...
     # artifacts = export(documents, tmp_path)
     # ... and read back the data to check that it looks right.
+
+
+def test_file_prefix_formatting(file_prefix_list, example_data, tmp_path):
+    '''Runs a test of the ``file_prefix`` formatting.
+    ..note::
+        Due to the `file_prefix_list` and `example_data` `pytest.fixture`'s
+        this will run multiple tests each with a range of file_prefixes,
+        detectors and event_types. See `suitcase.utils.conftest` for more info.
+    '''
+    collector = example_data()
+    file_prefix = file_prefix_list()
+    artifacts = export(collector, tmp_path, file_prefix=file_prefix)
+
+    for name, doc in collector:
+        if name == 'start':
+            templated_file_prefix = file_prefix.format(
+                start=doc).partition('-')[0]
+            break
+
+    if artifacts:
+        unique_actual = set(str(artifact).split('/')[-1].partition('-')[0]
+                            for artifact in artifacts['stream_data'])
+        assert unique_actual == set([templated_file_prefix])

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -32,5 +32,5 @@ def test_file_prefix_formatting(file_prefix_list, example_data, tmp_path):
 
     if artifacts:
         unique_actual = set(str(artifact).split('/')[-1].partition('-')[0]
-                            for artifact in artifacts['stream_data'])
+                            for artifact in artifacts['all'])
         assert unique_actual == set([templated_file_prefix])


### PR DESCRIPTION
This updates the `file_prefix` formatting .

##Previous approach
`file_prefix='{uid}'`
##New approach
`file_prefix='{start[uid]}'`