### PR TITLE
FIX: Remove trailing dash from default file_prefix.

### DIFF
--- a/suitcase/msgpack/__init__.py
+++ b/suitcase/msgpack/__init__.py
@@ -127,7 +127,7 @@ class Serializer(event_model.DocumentRouter):
         dict mapping the 'labels' to lists of file names (or, in general,
         whatever resources are produced by the Manager)
     """
-    def __init__(self, directory, file_prefix='{start[uid]}-', **kwargs):
+    def __init__(self, directory, file_prefix='{start[uid]}', **kwargs):
 
         self._file_prefix = file_prefix
         self._kwargs = kwargs


### PR DESCRIPTION
The trailing slash only makes sense if there is a postfix. Making files
like `{uid}-.msgpack` was not our intention.