### PR TITLE
ENH: Handle unfilled streams.

### DIFF
--- a/suitcase/msgpack/__init__.py
+++ b/suitcase/msgpack/__init__.py
@@ -175,6 +175,7 @@ class Serializer(event_model.DocumentRouter):
 
     def stop(self, doc):
         self._buffer.write(_encode(('stop', doc)))
+        self.close()
 
 
 def _encode(obj):

--- a/suitcase/msgpack/__init__.py
+++ b/suitcase/msgpack/__init__.py
@@ -177,6 +177,16 @@ class Serializer(event_model.DocumentRouter):
         self._buffer.write(_encode(('stop', doc)))
         self.close()
 
+    # This suitcase can be used to store "unfilled" Events, Events that
+    # reference external files using Datum[Page] and Resource documents.
+    # Not all suitcases do this.
+
+    def datum_page(self, doc):
+        self._buffer.write(_encode(('datum_page', doc)))
+
+    def resource(self, doc):
+        self._buffer.write(_encode(('resource', doc)))
+
 
 def _encode(obj):
     "Encode as msgpack using numpy-aware encoder."


### PR DESCRIPTION
Suitcases that generate user-facing files (TIFF, CSV, etc.) require filled data but suitcases that are more like "storage backends" (MongoDB, JSONL) can be used to store Datum and Resource documents with "unfilled" Events. The msgpack suitcase should be in that group too.