### PR TITLE
Remove tests package from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,7 @@ setup(
     cmdclass=versioneer.get_cmdclass(),
     long_description=readme,
     long_description_content_type='text/markdown',
-    packages=['suitcase.msgpack',
-              'suitcase.msgpack.tests'],
+    packages=['suitcase.msgpack'],
     entry_points={
         'console_scripts': [
             # 'some.module:some_function',


### PR DESCRIPTION
As with ``suitcase.csv``, the namespace package ``suitcase.msgpack``
confuses pytest because ``msgpack`` itself is also a package. We work
around this by putting the tests outside the pacakge, as noted in
suitcase/msgpack/tests/README.md.